### PR TITLE
intern strings for names, functions and files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ authors = ["Cody Tapscott <topolarity@tapscott.me>"]
 version = "0.1.0"
 
 [deps]
+InternedStrings = "7d512f48-7fb1-5a58-b986-67e6dc259f01"
 LibTracyClient_jll = "ad6e5548-8b26-5c9f-8ef3-ef0ad883f3a5"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
+InternedStrings = "0.7"
 julia = "1.6"

--- a/src/Tracy.jl
+++ b/src/Tracy.jl
@@ -7,7 +7,7 @@ The `Tracy` module provides the `@tracepoint` macro which can be used to create
 scoped regions for profiling with Tracy.
 
 `@tracepoint`s can be runtime enabled/disabled with `enable_tracepoint` or they
-can be erased from the generated code entirely using invalidation with 
+can be erased from the generated code entirely using invalidation with
 `configure_tracepoint`. The latter is effectively a "compile-time" enable/disable
 for tracing zones for ultra-low overhead.
 
@@ -19,6 +19,7 @@ module Tracy
 
 using LibTracyClient_jll: libTracyClient
 using Libdl: dllist, dlopen
+using InternedStrings: intern
 
 include("./cffi.jl")
 include("./tracepoint.jl")
@@ -81,7 +82,7 @@ function find_libtracy()
     end
 end
 
-# Register telemetry callbacks with Tracy 
+# Register telemetry callbacks with Tracy
 #
 # This is what allows `@tracepoint`s to be toggled from within the Tracy GUI
 function __init__()

--- a/src/tracepoint.jl
+++ b/src/tracepoint.jl
@@ -137,6 +137,10 @@ struct JuliaSrcLoc
     file::String
     line::UInt32
     color::UInt32
+    JuliaSrcLoc(name::Union{String, Nothing}, func::Union{String, Nothing}, file::String, line::Integer, color::Integer) =
+        new(name === nothing ? nothing : intern(name),
+            func === nothing ? nothing : intern(func),
+            intern(file), line, color)
 end
 
 


### PR DESCRIPTION
this ensures that we give the same pointer to Tracy for equal strings at different source locations. I had cases where I got multiple zones with the same name.
