### PR TITLE
RFC: rename `@tracepoint` to `@zone`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ A flexible profiling tool for tracing Julia code, LLVM compilation, Garbage Coll
 
 # Tracing Julia code
 
-Code you'd like to trace should be wrapped with `@tracepoint`
+Code you'd like to trace should be wrapped with `@zone`
 
 ```julia
-    @tracepoint "name" <expression>
+    @zone "name" <expression>
 ```
 
 Typically the expression will be a `begin-end` block:
 
 ```julia
-    @tracepoint "data aggregation" begin
+    @zone "data aggregation" begin
         # lots of compute here...
     end
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,8 +3,8 @@
 A flexible profiling tool for tracing Julia code, LLVM compilation, Garbage Collection, and more.
 
 ```@docs
-@tracepoint
-Tracy.@register_tracepoints
-Tracy.enable_tracepoint
-Tracy.configure_tracepoint
+@zone
+Tracy.@register_zones
+Tracy.enable_zone
+Tracy.configure_zone
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,11 +2,11 @@ module BasicTests
     using Tracy
     using Test
 
-    @tracepoint "test tracepoint" begin
+    @zone "test zone" begin
 	    println("Hello, world!")
     end
 
-    @test_throws ErrorException @tracepoint "test exception" begin
+    @test_throws ErrorException @zone "test exception" begin
         error("oh no!")
     end
 end


### PR DESCRIPTION
I think the current macro name `@tracepoint` has some disadvantages:

- It suggests that you are marking a single instantanous `point` in time. Natural usage of a "point" like trace would look like:
  ```julia
   foo()
   @tracepoint
   bar()
   ```
    to take a "snapshot" of the current state of the system. Similar to how you take a stack trace.
- It is a bit long.
- It isn't really a terminology that I think is used in the tracy manual.

My suggestion is the name `@zone`. It indicates that we are marking a region (not an instant), it is shorter and the usage
```julia
@zone begin
    ...
end
```
maps very nicely to the C api names where you begin and end a zone. And `zone` is what the tracy manual seems to use for this concept.

