### PR TITLE
allow attaching the `@tracepoint` macro directly to a function definition

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.9.0"
 manifest_format = "2.0"
-project_hash = "fa8b026b7f9ee39bd4224b76df5eba3b1d8b7ed7"
+project_hash = "d896969baf4ae0654412c9b5af365006ab230270"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -10,6 +10,11 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.ExprTools]]
+git-tree-sha1 = "c1d06d129da9f55715c6c212866f5b1bddc5fa00"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.9"
 
 [[deps.JLLWrappers]]
 deps = ["Preferences"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ authors = ["Cody Tapscott <cody.tapscott@juliahub.com>", "Kristoffer Carlsson <k
 version = "0.1.0"
 
 [deps]
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 LibTracyClient_jll = "ad6e5548-8b26-5c9f-8ef3-ef0ad883f3a5"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
+ExprTools = "0.1"
 julia = "1.6"
 
 [extras]

--- a/src/Tracy.jl
+++ b/src/Tracy.jl
@@ -19,6 +19,7 @@ module Tracy
 
 using LibTracyClient_jll: libTracyClient
 using Libdl: dllist, dlopen
+using ExprTools: splitdef, combinedef
 
 include("cffi.jl")
 include("colors.jl")

--- a/src/tracepoint.jl
+++ b/src/tracepoint.jl
@@ -76,7 +76,7 @@ function _tracepoint_func(name::Union{String, Nothing}, ex::Expr, mod::Module, s
     if haskey(def, :whereparams)
         def[:whereparams] = map(esc, def[:whereparams])
     end
-    def[:body] = _tracepoint(nothing, string(function_name), def[:body], mod, source)
+    def[:body] = _tracepoint(name, string(function_name), def[:body], mod, source)
     cdef = combinedef(def)
     # Replace function definition line number node with that from source
     @assert def[:body].args[1] isa LineNumberNode

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -54,4 +54,18 @@ TestPkg.test_data()
     tracymsg("system color magenta"; color=:magenta)
 end
 
+# Various ways to trace a function
+@tracepoint "zone f" f(x) = x^2
+foreach(n -> f(n), 1:10)
+@tracepoint function g(x)
+    x^2
+end
+foreach(n -> g(n), 1:20)
+@tracepoint "hxT" function h(x::T) where {T}
+    T(x^2)
+end
+foreach(n -> h(n), 1:30)
+i = @tracepoint x->x^2
+foreach(n -> i(n), 1:40)
+
 sleep(0.5)

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -54,8 +54,23 @@ TestPkg.test_data()
     tracymsg("system color magenta"; color=:magenta)
 end
 
+function check_stacktrace(function_name::Union{Symbol, Nothing}, filepath::AbstractString, line::Int)
+    trace = stacktrace()[2:end]
+
+    # Verify that the first stack frame is correct
+    caller = trace[1]
+    !isnothing(function_name) && @test caller.func == function_name
+    @test caller.file == Symbol(filepath)
+    @test caller.line == line
+
+    # And that no stack frame includes the actual macro source
+    for stackframe in trace
+        @test !contains(string(stackframe.file), "Tracy.jl/src")
+    end
+end
+
 # Various ways to trace a function
-@tracepoint "zone f" f(x) = x^2
+@tracepoint "zone f" f(x) = (check_stacktrace(nothing, @__FILE__(), @__LINE__()); x^2)
 foreach(n -> f(n), 1:10)
 @tracepoint function g(x)
     x^2
@@ -65,7 +80,7 @@ foreach(n -> g(n), 1:20)
     T(x^2)
 end
 foreach(n -> h(n), 1:30)
-i = @tracepoint x->x^2
+i = @tracepoint x->(check_stacktrace(nothing, @__FILE__(), @__LINE__()); x^2)
 foreach(n -> i(n), 1:40)
 
 sleep(0.5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,8 @@ else
                     @test zone.counts == "30"
                 elseif zone.name == "<anon>"
                     @test zone.counts == "40"
+                else
+                    error("unknown zone name")
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,15 +43,19 @@ else
             end
         end
 
+        all_names_recorded = Set([z.name for z in zones])
+        all_names_expected = Set(["test tracepoint", "test exception", "timing", "zone f", "g", "hxT", "<anon>"])
+        @test all_names_recorded == all_names_expected
+
         @testset "check zone data" begin
             for zone in zones
                 if zone.name == "test tracepoint"
                     @test Base.samefile(zone.src_file, joinpath(@__DIR__, "run_zones.jl"))
                     @test zone.counts == "3"
                     @test zone.src_line == "17"
-                elseif zone.name == "text exception"
+                elseif zone.name == "test exception"
                     @test zone.counts == "5"
-                    @test zone.src_line == "22"
+                    @test zone.src_line == "23"
                 elseif zone.name == "timing"
                     @test Base.samefile(zone.src_file, joinpath(@__DIR__, "TestPkg", "src", "TestPkg.jl"))
                     @test zone.counts == "100"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,15 @@ else
                     @test Base.samefile(zone.src_file, joinpath(@__DIR__, "TestPkg", "src", "TestPkg.jl"))
                     @test zone.counts == "100"
                     @test zone.src_line == "7"
+                elseif zone.name == "zone f"
+                    @test Base.samefile(zone.src_file, joinpath(@__DIR__, "run_zones.jl"))
+                    @test zone.counts == "10"
+                elseif zone.name == "g"
+                    @test zone.counts == "20"
+                elseif zone.name == "hxT"
+                    @test zone.counts == "30"
+                elseif zone.name == "<anon>"
+                    @test zone.counts == "40"
                 end
             end
         end


### PR DESCRIPTION
Fixes #12 

It is a common use case to time the full execution of a function. It is a bit awkward to write:

```julia
function f(x)
    @tracepoint "f" begin
        ...
    end
end
```

So this allows one to write

```julia
@tracepoint f(x)
    ...
end
```

instead. Running Tracy on the added test code (given here for convenience):

```julia
@tracepoint "zone f" f(x) = x^2
foreach(n -> f(n), 1:10)
@tracepoint function g(x)
    x^2
end
foreach(n -> g(n), 1:20)
@tracepoint "hxT" function h(x::T) where {T}
    T(x^2)
end
foreach(n -> h(n), 1:30)
i = @tracepoint x->x^2
foreach(n -> i(n), 1:40)

```

 gives:

![gnome-shell-screenshot-2u14fj](https://github.com/topolarity/Tracy.jl/assets/1282691/4383118a-8aa2-412d-b195-080fd539bd8d)

Regarding the new dependency, I think it is warranted. The AST for function definitions is quite rich and handling all the cases is not something that is so easy. The easiest way to do this without the dependency would be to copy paste the used parts from ExprTools.jl. The dependency is also pretty light weight:

```julia
julia> @time using ExprTools
  0.004472 seconds
```