### PR TITLE
wrap the message part of tracy and provide a color "framework" based on `printstyle`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,6 +4,7 @@ A flexible profiling tool for tracing Julia code, LLVM compilation, Garbage Coll
 
 ```@docs
 @tracepoint
+tracymsg
 Tracy.@register_tracepoints
 Tracy.enable_tracepoint
 Tracy.configure_tracepoint

--- a/src/Tracy.jl
+++ b/src/Tracy.jl
@@ -20,10 +20,13 @@ module Tracy
 using LibTracyClient_jll: libTracyClient
 using Libdl: dllist, dlopen
 
-include("./cffi.jl")
-include("./tracepoint.jl")
+include("cffi.jl")
+include("colors.jl")
+include("tracepoint.jl")
+include("msg.jl")
 
-export @tracepoint
+
+export @tracepoint, tracymsg
 
 # Remaining public API is:
 #   - `enable_tracepoint`

--- a/src/colors.jl
+++ b/src/colors.jl
@@ -1,0 +1,34 @@
+function _tracycolor((r,g,b)::Tuple{Integer, Integer, Integer})
+    @assert 0 <= r <= 255
+    @assert 0 <= g <= 255
+    @assert 0 <= b <= 255
+    return UInt32((r << 16) | (g << 8) | b)
+end
+
+# We are using the updated colorscheme from the Windows 10 console:
+# https://devblogs.microsoft.com/commandline/updating-the-windows-console-colors/
+# The symbol names are the same as for `printstyled`.
+function _tracycolor(sym::Symbol)
+    sym == :black         ? _tracycolor((12 , 12 , 12 )) :
+    sym == :blue          ? _tracycolor((0  , 55 , 218)) :
+    sym == :green         ? _tracycolor((19 , 161, 14 )) :
+    sym == :cyan          ? _tracycolor((58 , 150, 221)) :
+    sym == :red           ? _tracycolor((197, 15 , 31 )) :
+    sym == :magenta       ? _tracycolor((136, 23 , 152)) :
+    sym == :yellow        ? _tracycolor((193, 156, 0  )) :
+    sym == :white         ? _tracycolor((204, 204, 204)) :
+    sym == :light_black   ? _tracycolor((118, 118, 118)) :
+    sym == :light_blue    ? _tracycolor((59 , 120, 255)) :
+    sym == :light_green   ? _tracycolor((22 , 198, 12 )) :
+    sym == :light_cyan    ? _tracycolor((97 , 214, 214)) :
+    sym == :light_red     ? _tracycolor((231, 72 , 86 )) :
+    sym == :light_magenta ? _tracycolor((180, 0  , 158)) :
+    sym == :light_yellow  ? _tracycolor((249, 241, 165)) :
+    sym == :light_white   ? _tracycolor((242, 242, 242)) :
+    error("Unknown color: $sym")
+end
+
+function _tracycolor(num::Integer)
+    @assert 0 <= num <= 0xFFFFFF
+    return num
+end

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -1,0 +1,20 @@
+"""
+    tracymsg(msg::AbstractString; color::Union{Integer,Symbol,NTuple{3, Integer}, Nothing}=nothing, callstack_depth::Integer=0)
+
+Send a message to Tracy that gets shown in the "Message" window.
+If `color` is `nothing`, the default color is used.
+Otherwise, the `color` argument can be given as:
+- An integer: The hex code of the color as `0xRRGGBB`.
+- A symbol: Can take the value `:black`, `:blue`, `:green`, `:cyan`, `:red`, `:magenta`, `:yellow`, `:white`,
+  `:light_black`, `:light_blue`, `:light_green`, `:light_cyan`, `:light_red`, `:light_magenta`, `:light_yellow`, `:light_white`.
+- A tuple of three integers: The RGB value `(R, G, B)` where each value is in the range 0..255.
+
+The `callstack_depth` argument determines the depth of the callstack that is collected.
+"""
+function tracymsg(msg::AbstractString; color::Union{Integer,Symbol,NTuple{3,Integer},Nothing}=nothing, callstack_depth::Integer=0)
+    if color === nothing
+        @ccall libtracy.___tracy_emit_message(msg::Cstring, length(msg)::Csize_t, callstack_depth::Cint)::Cvoid
+    else
+        @ccall libtracy.___tracy_emit_messageC(msg::Cstring, length(msg)::Csize_t, _tracycolor(color)::UInt32, callstack_depth::Cint)::Cvoid
+    end
+end

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -31,5 +31,27 @@ using TestPkg
 TestPkg.time_something()
 TestPkg.test_data()
 
+@testset "msg" begin
+    tracymsg(SubString("Hello, world!"); color=0xFF00FF)
+    tracymsg(SubString("Hello, sailor!"); color=:red)
+
+    steps = 0:30:255
+    for r = steps
+        for g=steps
+            for b=steps
+                tracymsg("rgb color ($r, $g, $b)"; color=(r,g,b), callstack_depth=rand(1:5))
+            end
+            tracymsg("")
+        end
+        tracymsg("")
+    end
+
+    tracymsg("")
+    tracymsg("system color red"; color=:red)
+    tracymsg("system color green"; color=:green)
+    tracymsg("system color blue"; color=:blue)
+    tracymsg("system color yellow"; color=:yellow)
+    tracymsg("system color magenta"; color=:magenta)
+end
 
 sleep(0.5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test
 
 const connect_tracy_capture = true
 const connect_tracy_gui = false # useful for manually inspecting the output
-const verify_csv_output = sizeof(Int) == 8 && !Sys.iswindows()
+const verify_csv_output = sizeof(Int) == 8 && !Sys.iswindows() && !connect_tracy_gui
 
 const run_zone_path = joinpath(@__DIR__, "run_zones.jl")
 if !connect_tracy_capture && !connect_tracy_gui


### PR DESCRIPTION
Here are some screenshots from the tests:


<img width="552" alt="Screenshot 2023-05-16 at 21 18 20" src="https://github.com/topolarity/Tracy.jl/assets/1282691/8088c062-660b-49cd-af9e-15e1d5c10cd0">
