### PR TITLE
Connect to a server during testing to ensure tracy likes the data we emit.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.0-DEV"
+julia_version = "1.9.0"
 manifest_format = "2.0"
-project_hash = "6d4a2628950afed240674f1789460978631aa6dd"
+project_hash = "fa8b026b7f9ee39bd4224b76df5eba3b1d8b7ed7"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ julia = "1.6"
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TracyProfiler_jll = "0c351ed6-8a68-550e-8b79-de6f926da83c"
 
 [targets]
-test = ["Pkg", "Test"]
+test = ["Pkg", "Test", "TracyProfiler_jll"]

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -13,8 +13,10 @@ if haskey(ENV, "TRACYJL_WAIT_FOR_TRACY")
     @info "Connected!"
 end
 
-@tracepoint "test tracepoint" begin
-    println("Hello, world!")
+for i in 1:3
+    @tracepoint "test tracepoint" begin
+        println("Hello, world!")
+    end
 end
 
 for i in 1:5

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -1,0 +1,33 @@
+using Tracy
+using Test
+using Pkg
+
+# The line numbers in this file are relevant. If you change them, you must also
+# update the lines in `runtests.jl` that check the output.
+
+if haskey(ENV, "TRACYJL_WAIT_FOR_TRACY")
+    @info "Waiting for tracy to connect..."
+    while (@ccall Tracy.libtracy.___tracy_connected()::Cint) == 0
+        sleep(0.01)
+    end
+    @info "Connected!"
+end
+
+@tracepoint "test tracepoint" begin
+    println("Hello, world!")
+end
+
+for i in 1:5
+    @test_throws ErrorException @tracepoint "test exception" begin
+        error("oh no!")
+    end
+end
+
+Pkg.develop(; path = joinpath(@__DIR__, "TestPkg"), io=devnull)
+# Test that a precompiled package also works,
+using TestPkg
+TestPkg.time_something()
+TestPkg.test_data()
+
+
+sleep(0.5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ if !connect_tracy_capture && !connect_tracy_gui
 else
     # Spawn the headless tracy profiler, run the test script, and export the results to a CSV
     using TracyProfiler_jll
-    tmp = mktempdir()
+    tmp = mktempdir(; cleanup=false)#  mktempdir()
     tracyfile = joinpath(tmp, "tracyjltest.tracy")
 
     if connect_tracy_gui
@@ -29,7 +29,7 @@ else
         @warn "Not running CSV export test on 32-bit system or Windows"
     else
         csvfile = joinpath(tmp, "tracyjltest.csv")
-        run(pipeline(`$(TracyProfiler_jll.csvexport()) $(repr(tracyfile))`, stdout=csvfile))
+        run(pipeline(`$(TracyProfiler_jll.csvexport()) $tracyfile`, stdout=csvfile))
 
         # Parse the CSV file
         zones = []
@@ -47,8 +47,8 @@ else
             for zone in zones
                 if zone.name == "test tracepoint"
                     @test Base.samefile(zone.src_file, joinpath(@__DIR__, "run_zones.jl"))
-                    @test zone.counts == "1"
-                    @test zone.src_line == "16"
+                    @test zone.counts == "3"
+                    @test zone.src_line == "17"
                 elseif zone.name == "text exception"
                     @test zone.counts == "5"
                     @test zone.src_line == "22"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,21 +1,63 @@
-module BasicTests
-    using Tracy
-    using Test
-    using Pkg
+using Test
 
-    @tracepoint "test tracepoint" begin
-	    println("Hello, world!")
+const connect_tracy_capture = true
+const connect_tracy_gui = false # useful for manually inspecting the output
+const verify_csv_output = sizeof(Int) == 8 && !Sys.iswindows()
+
+const run_zone_path = joinpath(@__DIR__, "run_zones.jl")
+if !connect_tracy_capture && !connect_tracy_gui
+    include(run_zone_path)
+else
+    # Spawn the headless tracy profiler, run the test script, and export the results to a CSV
+    using TracyProfiler_jll
+    tmp = mktempdir()
+    tracyfile = joinpath(tmp, "tracyjltest.tracy")
+
+    if connect_tracy_gui
+        p = run(`$(TracyProfiler_jll.tracy()) -a 127.0.0.1 -p 9001`; wait=false)
+    else
+        p = run(`$(TracyProfiler_jll.capture()) -p 9001 -o $tracyfile -f`; wait=false)
     end
 
-    @test_throws ErrorException @tracepoint "test exception" begin
-        error("oh no!")
+    withenv("TRACYJL_WAIT_FOR_TRACY"=>1, "TRACY_PORT" => 9001) do
+        code = "include($(repr(run_zone_path)))"
+        run(`$(Base.julia_cmd()) --project=$(dirname(Base.active_project())) -e $code`)
     end
+    wait(p)
 
-    Pkg.activate("TestPkg")
-    Pkg.develop(; path = joinpath(@__DIR__, ".."))
-    # Test that a precompiled package also works,
-    # Can also be manually verified by attaching Tracy to this process
-    # withenv("JULIA_WAIT_FOR_TRACY"=>"1", "TRACY_PORT"=>"9000") do
-        run(`$(Base.julia_cmd()) --project="TestPkg" -e 'using TestPkg; TestPkg.time_something(); TestPkg.test_data()'`)
-    # end
+    if !verify_csv_output
+        @warn "Not running CSV export test on 32-bit system or Windows"
+    else
+        csvfile = joinpath(tmp, "tracyjltest.csv")
+        run(pipeline(`$(TracyProfiler_jll.csvexport()) $(repr(tracyfile))`, stdout=csvfile))
+
+        # Parse the CSV file
+        zones = []
+        open(csvfile) do io
+            header = readline(io) # header
+            colnames = Symbol.(split(header, ','))
+            while !eof(io)
+                fields = split(readline(io), ',')
+                nt = (; zip(colnames, fields)...)
+                push!(zones, nt)
+            end
+        end
+
+        @testset "check zone data" begin
+            for zone in zones
+                if zone.name == "test tracepoint"
+                    @test Base.samefile(zone.src_file, joinpath(@__DIR__, "run_zones.jl"))
+                    @test zone.counts == "1"
+                    @test zone.src_line == "16"
+                elseif zone.name == "text exception"
+                    @test zone.counts == "5"
+                    @test zone.src_line == "22"
+                elseif zone.name == "timing"
+                    @test Base.samefile(zone.src_file, joinpath(@__DIR__, "TestPkg", "src", "TestPkg.jl"))
+                    @test zone.counts == "100"
+                    @test zone.src_line == "7"
+                end
+            end
+        end
+    end
 end


### PR DESCRIPTION
In this commit, we spawn a headless tracy server and connect it to a
process that runs instrumented code. This ensures that the checks in the
tracy server are being run which provides extra verification that our
implementation is correct.

In addition to this, we are now emitting a CSV file from the recorded profile data. This allows us to verify that the zones are being sent to Tracy as intended.

Finally, we've made a quality-of-life improvement to `runtests.jl`. By setting `connect_tracy_gui` to `true`, we automatically connected to a process running the instrumented thereby facilitating the manual inspection of profiling results.

