### PR TITLE
make type of `enabled` field correspond to type for ccall

### DIFF
--- a/src/cffi.jl
+++ b/src/cffi.jl
@@ -16,7 +16,7 @@ mutable struct TracySrcLoc
     # branch of Tracy, but its usage is designed to be backwards-compatible with prior
     # Tracy versions:
     module_name::Ptr{UInt8} # nameof(__module__) (Julia-specific)
-    enabled::UInt64         # 0 = runtime-disabled, 1 = runtime-enabled, 0xff = compile-time-disabled
+    enabled::Cint        # 0 = runtime-disabled, 1 = runtime-enabled, 0xff = compile-time-disabled
 
     # These are used to reinitialize the pointers above since
     # pointers are only valid in a given Julia session.


### PR DESCRIPTION
Looking at the generated code for a tracy zone instrumented function I noticed:

```
; │┌ @ essentials.jl:492 within `cconvert`
; ││┌ @ number.jl:7 within `convert`
; │││┌ @ boot.jl:783 within `Int32`
; ││││┌ @ boot.jl:698 within `toInt32`
; │││││┌ @ boot.jl:648 within `check_top_bit`
; ││││││┌ @ boot.jl:638 within `is_top_bit_set`
         %12 = icmp sgt i64 %11, -1
; ││││││└
        br i1 %12, label %L16, label %L13

L13:                                              ; preds = %L7
        call void @j_throw_inexacterror_240({}* inttoptr (i64 4344453408 to {}*), i64 zeroext %11) #6
        unreachable
```

These comes from the enable argument being a `Cint` in C but a `UInt64` input. `ccvonvert` checks that we do not overflow on conversion.

Might as well make these equal to clean up the generated code a bit.