### PR TITLE
wrap the plot part of tracy

### DIFF
--- a/src/Tracy.jl
+++ b/src/Tracy.jl
@@ -24,9 +24,10 @@ include("cffi.jl")
 include("colors.jl")
 include("tracepoint.jl")
 include("msg.jl")
+include("plot.jl")
 
 
-export @tracepoint, tracymsg
+export @tracepoint, tracyplot, tracyplot_config, tracymsg
 
 # Remaining public API is:
 #   - `enable_tracepoint`

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -4,7 +4,7 @@
 Configures a plot with the given name. Should typically be called once per plot.
 
 - The `format` parameter can be one of `:number`, `:memory`, or `:percentage`.
-- The `step`` parameter determines whether the plot will be displayed as a staircase or will smoothly change between plot points
+- The `step` parameter determines whether the plot will be displayed as a staircase or will smoothly change between plot points
 - The `fill` parameter can be used to disable filling the area below the plot with a solid color.
 
 If `color` is `nothing`, the default color is used.

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,7 +1,7 @@
 """
     tracyplot_config(name::String; format::Symbol=:number, step::Bool=false, fill::Bool=true, color::Union{Integer,Symbol,NTuple{3, Integer}, Nothing}=nothing)
 
-Configures a plot with the given name. Should typically be called once.
+Configures a plot with the given name. Should typically be called once per plot.
 
 - The `format` parameter can be one of `:number`, `:memory`, or `:percentage`.
 - The `step`` parameter determines whether the plot will be displayed as a staircase or will smoothly change between plot points

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,0 +1,42 @@
+"""
+    tracyplot_config(name::String; format::Symbol=:number, step::Bool=false, fill::Bool=true, color::Union{Integer,Symbol,NTuple{3, Integer}, Nothing}=nothing)
+
+Configures a plot with the given name. Should typically be called once.
+
+- The `format` parameter can be one of `:number`, `:memory`, or `:percentage`.
+- The `step`` parameter determines whether the plot will be displayed as a staircase or will smoothly change between plot points
+- The `fill` parameter can be used to disable filling the area below the plot with a solid color.
+
+If `color` is `nothing`, the default color is used.
+Otherwise, the `color` argument can be given as:
+- An integer: The hex code of the color as `0xRRGGBB`.
+- A symbol: Can take the value `:black`, `:blue`, `:green`, `:cyan`, `:red`, `:magenta`, `:yellow`, `:white`,
+  `:light_black`, `:light_blue`, `:light_green`, `:light_cyan`, `:light_red`, `:light_magenta`, `:light_yellow`, `:light_white`.
+- A tuple of three integers: The RGB value `(R, G, B)` where each value is in the range 0..255.
+
+See also: [`tracyplot`](@ref).
+"""
+function tracyplot_config(name::String; format::Symbol=:number, step::Bool=false, fill::Bool=true, color::Union{Integer,Symbol,NTuple{3, Integer}, Nothing}=nothing)
+    tracyformat = format == :number     ? 0 :
+                  format == :memory     ? 1 :
+                  format == :percentage ? 2 :
+                  error("Invalid format: $(repr(format)), must be one of :number, :memory, or :percentage")
+    @ccall libtracy.___tracy_emit_plot_config(name::Cstring, tracyformat::Cint, step::Cint, fill::Cint, _tracycolor(color)::UInt32)::Cvoid
+end
+
+"""
+    tracyplot(name::String, value::Number)
+
+Plots the given `value` on the plot with the given `name`.
+
+See also: [`tracyplot_config`](@ref).
+"""
+function tracyplot(name::String, v::Number)
+    if v isa Integer
+        @ccall libtracy.___tracy_emit_plot_int(name::Cstring, v::Cint)::Cvoid
+    elseif v isa Float32
+        @ccall libtracy.___tracy_emit_plot_float(name::Cstring, v::Cfloat)::Cvoid
+    else
+        @ccall libtracy.___tracy_emit_plot(name::Cstring, v::Cdouble)::Cvoid
+    end
+end

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -54,4 +54,13 @@ TestPkg.test_data()
     tracymsg("system color magenta"; color=:magenta)
 end
 
+tracyplot_config("sin"; fill=false, color=0xFF00FF)
+tracyplot_config("cos"; format=:percentage, step=true, fill=true, color=0x0000FF)
+
+for x in range(0, 2pi, 100)
+    tracyplot("sin", sin(x))
+    tracyplot("cos", 100*cos(x))
+    sleep(0.005)
+end
+
 sleep(0.5)


### PR DESCRIPTION

<img width="633" alt="Screenshot 2023-05-18 at 21 36 10" src="https://github.com/topolarity/Tracy.jl/assets/1282691/542d365f-051b-45ef-9f23-d4da56c2e0fd">


Originally I did this with some macro that could take keyword arguments and then you would use it as

```
for i in 1:10
    @tracyplot "sin(x)" color=0x00FF00 format=:numbered i
end
```

but it turned out not great.

- It feels weird to repeat config properties like `color` and `format` inside the loop.
- The fact that it is a macro makes it feel more magic than it is.

So I decided just to follow the tracy functions and wrap them normally. Users can either configure plots at toplevel in scripts, in `__init__` or just in a function and keep track of the configuration status with a flag.