### PR TITLE
WIP: allow setting metadata on zones

### DIFF
--- a/src/Tracy.jl
+++ b/src/Tracy.jl
@@ -20,6 +20,7 @@ module Tracy
 using LibTracyClient_jll: libTracyClient
 using Libdl: dllist, dlopen
 
+include("utils.jl")
 include("cffi.jl")
 include("colors.jl")
 include("tracepoint.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,16 @@
+function extract_keywords(ex0)
+    kws = Dict{Symbol, Any}()
+    arg = ex0[end]
+    for i in 1:length(ex0)-1
+        x = ex0[i]
+        if x isa Expr && x.head === :(=) # Keyword given of the form "foo=bar"
+            if length(x.args) != 2
+               error("Invalid keyword argument: $x")
+            end
+            kws[x.args[1]] = esc(x.args[2])
+        else
+            return error("@tracepoint expects only one non-keyword argument")
+        end
+    end
+    return kws, arg
+end

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -54,4 +54,13 @@ TestPkg.test_data()
     tracymsg("system color magenta"; color=:magenta)
 end
 
+colors = [0x00FF00, (30, 60, 90), :yellow]
+names = ["SLP", "SROA", "inlining"]
+text = ["ok", 0, "bad"]
+for i in 1:3
+    @tracepoint "optimizations" color=colors[i] name2=names[i] text=text[i] begin
+        sleep(0.1)
+    end
+end
+
 sleep(0.5)


### PR DESCRIPTION
This will take some iterations and feedback to get right I think @topolarity.

First, the code in the test produces:

![gnome-shell-screenshot-8e16j5](https://github.com/topolarity/Tracy.jl/assets/1282691/770ec41a-28fb-462a-ba44-149c40aa9d04)

Some remarks:

- You probably want to be able to set the "default" color of a zone at a location (which is stored in the `TracySrcLoc`) as well as being able to set a "highlighting" color which is passed as a runtime call. That suggests we need two arguments for the color. So the question is what should they be called, `color` and `dynamic_color`?
- The same applies to the name. `name` and `dynamic_name`?
- The non-dynamic expressions need to be statically evaluable.

TODO:

- [ ] Update docs
- [ ] Decide on names (right now there is placeholder `name2` as an example).
