### PR TITLE
allow setting the color via a literal

### DIFF
--- a/src/Tracy.jl
+++ b/src/Tracy.jl
@@ -21,6 +21,14 @@ using LibTracyClient_jll: libTracyClient
 using Libdl: dllist, dlopen
 using ExprTools: splitdef, combinedef
 
+const color_docstr = """
+- An integer: The hex code of the color as `0xRRGGBB`.
+- A symbol: Can take the value `:black`, `:blue`, `:green`, `:cyan`, `:red`, `:magenta`, `:yellow`, `:white`,
+  `:light_black`, `:light_blue`, `:light_green`, `:light_cyan`, `:light_red`, `:light_magenta`, `:light_yellow`, `:light_white`.
+- A tuple of three integers: The RGB value `(R, G, B)` where each value is in the range 0..255.
+"""
+
+include("utils.jl")
 include("cffi.jl")
 include("colors.jl")
 include("tracepoint.jl")

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -4,10 +4,7 @@
 Send a message to Tracy that gets shown in the "Message" window.
 If `color` is `nothing`, the default color is used.
 Otherwise, the `color` argument can be given as:
-- An integer: The hex code of the color as `0xRRGGBB`.
-- A symbol: Can take the value `:black`, `:blue`, `:green`, `:cyan`, `:red`, `:magenta`, `:yellow`, `:white`,
-  `:light_black`, `:light_blue`, `:light_green`, `:light_cyan`, `:light_red`, `:light_magenta`, `:light_yellow`, `:light_white`.
-- A tuple of three integers: The RGB value `(R, G, B)` where each value is in the range 0..255.
+$color_docstr
 
 The `callstack_depth` argument determines the depth of the callstack that is collected.
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,16 @@
+function extract_keywords(ex0)
+    kws = Dict{Symbol, Any}()
+    arg = ex0[end]
+    for i in 1:length(ex0)-1
+        x = ex0[i]
+        if x isa Expr && x.head === :(=) # Keyword given of the form "foo=bar"
+            if length(x.args) != 2
+               error("Invalid keyword argument: $x")
+            end
+            kws[x.args[1]] = x.args[2]
+        else
+            return error("@tracepoint expects only one non-keyword argument")
+        end
+    end
+    return kws, arg
+end

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -92,4 +92,20 @@ for x in range(0, 2pi, 100)
     sleep(0.005)
 end
 
+for j in 1:5
+    @tracepoint "SLP" color=0x00FF00 begin
+        sleep(0.01)
+    end
+end
+for j in 1:10
+    @tracepoint "SROA" color=(10, 20, 30) begin
+        sleep(0.01)
+    end
+end
+for j in 1:15
+    @tracepoint "Inlining" color=:red begin
+        sleep(0.01)
+    end
+end
+
 sleep(0.5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ else
         end
 
         all_names_recorded = Set([z.name for z in zones])
-        all_names_expected = Set(["test tracepoint", "test exception", "timing", "zone f", "g", "hxT", "<anon>"])
+        all_names_expected = Set(["test tracepoint", "test exception", "timing", "zone f", "g", "hxT", "<anon>", "SLP", "SROA", "Inlining"])
         @test all_names_recorded == all_names_expected
 
         @testset "check zone data" begin
@@ -69,6 +69,12 @@ else
                     @test zone.counts == "30"
                 elseif zone.name == "<anon>"
                     @test zone.counts == "40"
+                elseif zone.name == "SLP"
+                    @test zone.counts == "5"
+                elseif zone.name == "SROA"
+                    @test zone.counts == "10"
+                elseif zone.name == "Inlining"
+                    @test zone.counts == "15"
                 else
                     error("unknown zone name")
                 end


### PR DESCRIPTION
Incremental step towards #20 

I wonder why compile time is so bad:
```
julia> @time @tracepoint "sqrt" color=:green sqrt(x) # green
  5.353853 seconds (16.43 M allocations: 1023.168 MiB, 6.47% gc time, 100.00% compilation time)
```

Edit: Nvm, it is `sqrt(x)` which is slow when x is a matrix

```
julia> @time sqrt(x)
  5.598828 seconds (17.48 M allocations: 1.068 GiB, 6.48% gc time, 100.00% compilation time)
```