### PR TITLE
Add `wait_for_tracy()` export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+docs/build
+*.jl.*.cov

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,13 +1,16 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.0-rc2"
+julia_version = "1.9.0"
 manifest_format = "2.0"
-project_hash = "e0c77beb18dc1f6cce661ebd60658c0c1a77390f"
+project_hash = "87af204eb9b7ccb741570d3d757aae61b5992ecf"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
 uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 version = "0.0.1"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -28,6 +31,11 @@ git-tree-sha1 = "58fea7c536acd71f3eef6be3b21c0df5f3df88fd"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "0.27.24"
 
+[[deps.ExprTools]]
+git-tree-sha1 = "c1d06d129da9f55715c6c212866f5b1bddc5fa00"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.9"
+
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
 git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
@@ -38,6 +46,12 @@ version = "0.2.2"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[deps.JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.1"
+
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
@@ -47,6 +61,15 @@ version = "0.21.4"
 [[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibTracyClient_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "37adf58d446423b7899e9d343d3f2d3522e98bb1"
+uuid = "ad6e5548-8b26-5c9f-8ef3-ef0ad883f3a5"
+version = "0.9.1+2"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -110,6 +133,12 @@ version = "1.0.3"
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.Tracy]]
+deps = ["ExprTools", "LibTracyClient_jll", "Libdl"]
+path = ".."
+uuid = "e689c965-62c8-4b79-b2c5-8359227902fd"
+version = "0.1.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Tracy = "e689c965-62c8-4b79-b2c5-8359227902fd"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,4 +8,5 @@ tracymsg
 Tracy.@register_tracepoints
 Tracy.enable_tracepoint
 Tracy.configure_tracepoint
+Tracy.wait_for_tracy
 ```

--- a/src/Tracy.jl
+++ b/src/Tracy.jl
@@ -36,7 +36,7 @@ include("msg.jl")
 include("plot.jl")
 
 
-export @tracepoint, tracyplot, tracyplot_config, tracymsg
+export @tracepoint, tracyplot, tracyplot_config, tracymsg, wait_for_tracy
 
 # Remaining public API is:
 #   - `enable_tracepoint`

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,3 +14,20 @@ function extract_keywords(ex0)
     end
     return kws, arg
 end
+
+"""
+    wait_for_tracy(;timeout::Float64 = 20.0)
+
+Waits up to `timeout` seconds for `libtracy` to connect to a listening capture
+agent.  If a timeout occurs, throws an `InvalidStateException`.
+"""
+function wait_for_tracy(;timeout::Float64 = 20.0)
+    t_start = time()
+    while (time() - t_start) < timeout
+        if (@ccall libtracy.___tracy_connected()::Cint) == 1
+            return
+        end
+        sleep(0.01)
+    end
+    throw(InvalidStateException("Could not connect to tracy client", :timeout))
+end

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -8,8 +8,6 @@ using Pkg
 if haskey(ENV, "TRACYJL_WAIT_FOR_TRACY")
     @info "Waiting for tracy to connect..."
     wait_for_tracy()
-
-    # Keep line numbers the same
     @info "Connected!"
 end
 

--- a/test/run_zones.jl
+++ b/test/run_zones.jl
@@ -7,9 +7,9 @@ using Pkg
 
 if haskey(ENV, "TRACYJL_WAIT_FOR_TRACY")
     @info "Waiting for tracy to connect..."
-    while (@ccall Tracy.libtracy.___tracy_connected()::Cint) == 0
-        sleep(0.01)
-    end
+    wait_for_tracy()
+
+    # Keep line numbers the same
     @info "Connected!"
 end
 


### PR DESCRIPTION
This gives user code that is running on a non-instrumented build a way to replicate the logic from `JULIA_WAIT_FOR_TRACY=1`, e.g. waiting until the tracy profiler connects.  This allows for easier synchronization of relevant workload, e.g. starting a task that will run the workload which immediately blocks on waiting for tracy, then starting up the capture agent.