### PR TITLE
Add `Tracy.capture(outpath)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,15 @@ ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 LibTracyClient_jll = "ad6e5548-8b26-5c9f-8ef3-ef0ad883f3a5"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
+[weakdeps]
+TracyProfiler_jll = "0c351ed6-8a68-550e-8b79-de6f926da83c"
+
 [compat]
 ExprTools = "0.1"
 julia = "1.6"
+
+[extensions]
+TracyProfilerExt = "TracyProfiler_jll"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Tracy = "e689c965-62c8-4b79-b2c5-8359227902fd"
+TracyProfiler_jll = "0c351ed6-8a68-550e-8b79-de6f926da83c"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
-using Documenter, Tracy
+using Documenter, Tracy, TracyProfiler_jll
 
-DocMeta.setdocmeta!(Tracy, :DocTestSetup, :(using Tracy); recursive=true)
+DocMeta.setdocmeta!(Tracy, :DocTestSetup, :(using Tracy, TracyProfiler_jll); recursive=true)
 makedocs(modules = [Tracy], sitename="Tracy.jl")
 
 deploydocs(repo = "github.com/topolarity/Tracy.jl.git")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,4 +9,5 @@ Tracy.@register_tracepoints
 Tracy.enable_tracepoint
 Tracy.configure_tracepoint
 Tracy.wait_for_tracy
+Tracy.capture
 ```

--- a/ext/TracyProfilerExt.jl
+++ b/ext/TracyProfilerExt.jl
@@ -1,0 +1,13 @@
+module TracyProfilerExt
+
+using Tracy, TracyProfiler_jll
+
+function Tracy._capture(outfile::String, dummy::Symbol; gui::Bool = false, port::Int64 = 9001)
+    if gui
+        run(`$(TracyProfiler_jll.tracy()) -a 127.0.0.1 -p $(port)`; wait=false)
+    else
+        run(`$(TracyProfiler_jll.capture()) -p $(port) -o $(outfile) -f`; wait=false)
+    end
+end
+
+end # module

--- a/ext/TracyProfilerExt.jl
+++ b/ext/TracyProfilerExt.jl
@@ -2,12 +2,12 @@ module TracyProfilerExt
 
 using Tracy, TracyProfiler_jll
 
-function Tracy._capture(outfile::String, dummy::Symbol; gui::Bool = false, port::Int64 = 9001)
-    if gui
-        run(`$(TracyProfiler_jll.tracy()) -a 127.0.0.1 -p $(port)`; wait=false)
-    else
-        run(`$(TracyProfiler_jll.capture()) -p $(port) -o $(outfile) -f`; wait=false)
-    end
+function Tracy._capture(outfile::String, dummy::Symbol; port::Integer = 9001)
+    run(`$(TracyProfiler_jll.capture()) -p $(port) -o $(outfile) -f`; wait=false)
+end
+
+function Tracy._gui(dummy::Symbol; port::Integer = 9001)
+    run(`$(TracyProfiler_jll.tracy()) -a 127.0.0.1 -p $(port)`; wait=false)
 end
 
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,7 +36,21 @@ end
     capture(outfile::String; gui::Bool = false, port::Int64 = 9001)
 
 Starts a Tracy capture agent running in the background.  Returns the `Cmd` object for use
-with `wait()`.
+with `wait()`.  Note that if you are using a tracy-enabled build of Julia, you will need
+to ensure that the capture agent is running before the Julia executable starts, otherwise
+the capture agent may not see the beginning of every zone, which it considers to be a
+fatal error.
+
+The recommended methodology for usage of this function is something similar to:
+
+```
+    port = 9000 + rand(1:1000)
+    p = Tracy.capture("inverter.tracy"; port)
+    run(addenv(`\$(Base.julia_cmd()) workload.jl`,
+               "TRACY_PORT" => string(port),
+               "JULIA_WAIT_FOR_TRACY" => "1"))
+    wait(p)
+```
 
 !!! note
     This command is only available if you also load `TracyProfiler_jll`.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,7 +33,8 @@ function wait_for_tracy(;timeout::Float64 = 20.0)
 end
 
 """
-    capture(outfile::String; gui::Bool = false, port::Int64 = 9001)
+    capture(outfile::String; port::Integer = 9001)
+    gui(; port::Integer = 9001)
 
 Starts a Tracy capture agent running in the background.  Returns the `Cmd` object for use
 with `wait()`.  Note that if you are using a tracy-enabled build of Julia, you will need
@@ -45,7 +46,7 @@ The recommended methodology for usage of this function is something similar to:
 
 ```
     port = 9000 + rand(1:1000)
-    p = Tracy.capture("inverter.tracy"; port)
+    p = Tracy.capture("my_workload.tracy"; port)
     run(addenv(`\$(Base.julia_cmd()) workload.jl`,
                "TRACY_PORT" => string(port),
                "JULIA_WAIT_FOR_TRACY" => "1"))
@@ -56,4 +57,7 @@ The recommended methodology for usage of this function is something similar to:
     This command is only available if you also load `TracyProfiler_jll`.
 """
 capture(outfile::String; kwargs...) = _capture(outfile, :dummy; kwargs...)
-_capture(outfile::String, dummy) = error("TracyProfiler_jll not loaded")
+_capture(outfile::String, dummy; kwargs...) = error("TracyProfiler_jll not loaded")
+
+gui(;kwargs...) = _gui(:dummy, kwargs...)
+_gui(dummy; kwargs...) = error("TracyProfiler_jll not loaded")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -31,3 +31,15 @@ function wait_for_tracy(;timeout::Float64 = 20.0)
     end
     throw(InvalidStateException("Could not connect to tracy client", :timeout))
 end
+
+"""
+    capture(outfile::String; gui::Bool = false, port::Int64 = 9001)
+
+Starts a Tracy capture agent running in the background.  Returns the `Cmd` object for use
+with `wait()`.
+
+!!! note
+    This command is only available if you also load `TracyProfiler_jll`.
+"""
+capture(outfile::String; kwargs...) = _capture(outfile, :dummy; kwargs...)
+_capture(outfile::String, dummy) = error("TracyProfiler_jll not loaded")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,10 +33,10 @@ else
 
 
     p = Tracy.capture(tracyfile; gui=connect_tracy_gui, port=tracy_port)
-    withenv("TRACYJL_WAIT_FOR_TRACY"=>1, "TRACY_PORT" => string(tracy_port)) do
-        code = "include($(repr(run_zones_path)))"
-        run(`$(Base.julia_cmd()) --project=$(dirname(Base.active_project())) -e $code`)
-    end
+    code = "include($(repr(run_zones_path)))"
+
+    run(addenv(`$(Base.julia_cmd()) --project=$(dirname(Base.active_project())) -e $code`,
+               "TRACYJL_WAIT_FOR_TRACY"=>1, "TRACY_PORT" => string(tracy_port)))
     wait(p)
 
     if !verify_csv_output

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,11 @@ else
     tracyfile = joinpath(tmp, "tracyjltest.tracy")
 
 
-    p = Tracy.capture(tracyfile; gui=connect_tracy_gui, port=tracy_port)
+    if connect_tracy_gui
+        p = Tracy.guii(; port=tracy_port)
+    else
+        p = Tracy.capture(tracyfile; port=tracy_port)
+    end
     code = "include($(repr(run_zones_path)))"
 
     run(addenv(`$(Base.julia_cmd()) --project=$(dirname(Base.active_project())) -e $code`,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test
+using Test, Tracy
 
 const connect_tracy_capture = true
 const connect_tracy_gui = false # useful for manually inspecting the output
@@ -31,12 +31,8 @@ else
     tmp = mktempdir(; cleanup=false)#  mktempdir()
     tracyfile = joinpath(tmp, "tracyjltest.tracy")
 
-    if connect_tracy_gui
-        p = run(`$(TracyProfiler_jll.tracy()) -a 127.0.0.1 -p $(tracy_port)`; wait=false)
-    else
-        p = run(`$(TracyProfiler_jll.capture()) -p $(tracy_port) -o $tracyfile -f`; wait=false)
-    end
 
+    p = Tracy.capture(tracyfile; gui=connect_tracy_gui, port=tracy_port)
     withenv("TRACYJL_WAIT_FOR_TRACY"=>1, "TRACY_PORT" => string(tracy_port)) do
         code = "include($(repr(run_zones_path)))"
         run(`$(Base.julia_cmd()) --project=$(dirname(Base.active_project())) -e $code`)


### PR DESCRIPTION
This allows easy capturing of traces using `TracyProfiler_jll`.  To avoid forcing all users to download a potentially large JLL, we make use of the weakdeps system to enable this functionality when `TracyProfiler_jll` is also loaded.