### PR TITLE
Use `Base.Linking.private_libdir()` for base libTracyClient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tracy"
 uuid = "e689c965-62c8-4b79-b2c5-8359227902fd"
 authors = ["Cody Tapscott <cody.tapscott@juliahub.com>", "Kristoffer Carlsson <kristoffer.carlsson@juliahub.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"


### PR DESCRIPTION
It is a problem for relocatability for us to resolve the path from `dllist()` at pre-compile time, so instead we resolve it at `__init__()` by looking directly in the private libdir.

Eventually, this should be moved into its own stdlib, in which case we can use the library from `LibTracyClient_jll` directly.