### PR TITLE
Look for `libTracyClient.so` in the non-private libdir

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tracy"
 uuid = "e689c965-62c8-4b79-b2c5-8359227902fd"
 authors = ["Cody Tapscott <cody.tapscott@juliahub.com>", "Kristoffer Carlsson <kristoffer.carlsson@juliahub.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"


### PR DESCRIPTION
We only move `libTracyClient` to the private libdir during `install`.

We should check the non-private libdir also to support local builds.